### PR TITLE
Add function to remove a local branch

### DIFF
--- a/git-trim
+++ b/git-trim
@@ -11,52 +11,21 @@ https://github.com/jasonmccreary/git-trim/
 --
   Available options are:
 all!              remove all local branches, except the current branch
+dry-run!          prints branches to output instead of deleting theme
 m,merged!         remove local branches already merged into the current branch
 p,pruned!         remove local branches where its remote branch no longer exists
-s,stale!          remove local branches without commits in the last 3 months
-u,untracked!      remove local branches not tracking a remote branch
-t,tracked!        remove the tracking branch from remote
 r,remote!         remove remote branches instead of local branches
-dry-run!          prints branches to output instead of deleting theme
 reset=?           remove all local branches except those existing on remote (default: origin)
+s,stale!          remove local branches without commits in the last 3 months
+t,tracked!        remove the tracking branch from remote
+u,untracked!      remove local branches not tracking a remote branch
 "
 
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
-# Defaults
-all=0
-merged=0
-pruned=0
-stale=0
-tracked=0
-untracked=0
-remote=0
-reset=''
-dry_run=0
-current_branch=$(git symbolic-ref -q --short HEAD)
-[ $# != 1 ] || pruned=1
-
-# Parse options
-while [ $# != 0 ]; do
-  case "$1" in
-  --all) all=1;;
-  --stale) stale=1;;
-  --merged) merged=1;;
-  --pruned) pruned=1;;
-  --tracked) tracked=1;;
-  --untracked) untracked=1;;
-  --remote) remote=1;;
-  --reset=*) reset="${1#*=}";;
-  --reset) reset='origin';;
-  --dry-run) dry_run=1;;
-  --) ;;
-  esac
-  shift
-done
-
 # Functions
 filter_branches() {
-  local exclude=( $(git config gt.exclude) )
+  local exclude=($(git config gt.exclude))
 
   if [ ${#exclude} -eq 0 ]; then
     echo "$@"
@@ -83,7 +52,7 @@ filter_branches() {
 }
 
 prune_all() {
-  git fetch --all -p > /dev/null 2>&1
+  git fetch --all -p >/dev/null 2>&1
 }
 
 remove_tracking_branch() {
@@ -100,27 +69,62 @@ remove_tracking_branch() {
 }
 
 remove_remote_branch() {
-  git push -d $1 $2 > /dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    echo "Deleted branch $2 (on $1)."
+  if [ $dry_run -eq 1 ]; then
+    echo "$2 (on $1) will be trimmed."
+  else
+    git push -d $1 $2 >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "Deleted branch $2 (on $1)."
+    fi
   fi
 }
 
 remove_local_branch() {
-  if [ $dry -eq 1 ]; then
-    echo "${$1} will be trimmed."
+  if [ $dry_run -eq 1 ]; then
+    echo "$1 will be trimmed."
   else
     git branch -D $1
   fi
 }
+
+# Defaults
+all=0
+dry_run=0
+merged=0
+pruned=0
+remote=0
+reset=''
+stale=0
+tracked=0
+untracked=0
+current_branch=$(git symbolic-ref -q --short HEAD)
+[ $# != 1 ] || pruned=1
+
+# Parse options
+while [ $# != 0 ]; do
+  case "$1" in
+  --all) all=1 ;;
+  --stale) stale=1 ;;
+  --merged) merged=1 ;;
+  --pruned) pruned=1 ;;
+  --tracked) tracked=1 ;;
+  --untracked) untracked=1 ;;
+  --remote) remote=1 ;;
+  --reset=*) reset="${1#*=}" ;;
+  --reset) reset='origin' ;;
+  --dry-run) dry_run=1 ;;
+  --) ;;
+  esac
+  shift
+done
 
 # all
 if [ $all -eq 1 ]; then
   while true; do
     read -p "Are you sure you want to remove all branches? " choice
     case $(echo $choice | tr '[A-Z]' '[a-z]') in
-      y|yes) break;;
-      *) exit;;
+    y | yes) break ;;
+    *) exit ;;
     esac
   done
 
@@ -130,8 +134,8 @@ if [ $all -eq 1 ]; then
     command="$command -a"
   fi
 
-  branches=( $($command | grep -vF $current_branch) )
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($($command | grep -vF $current_branch))
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "No branches need to be trimmed."
@@ -154,7 +158,6 @@ if [ $all -eq 1 ]; then
   done
 fi
 
-
 # merged
 if [ $merged -eq 1 ]; then
   command='git branch'
@@ -163,8 +166,8 @@ if [ $merged -eq 1 ]; then
     command="$command -r"
   fi
 
-  branches=( $($command --merged | grep -vF $current_branch ) )
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($($command --merged | grep -vF $current_branch))
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no merged branches to trim."
@@ -175,7 +178,7 @@ if [ $merged -eq 1 ]; then
     if [ $remote -eq 1 ]; then
       remove_remote_branch ${branch%/*} ${branch#*/}
     else
-      
+
       if [ $tracked -eq 1 ]; then
         remove_tracking_branch $branch
       fi
@@ -185,12 +188,11 @@ if [ $merged -eq 1 ]; then
   done
 fi
 
-
 # pruned
 if [ $pruned -eq 1 ]; then
   prune_all
-  branches=( $(LANG=C git branch -vv | awk '/: gone]/{print $1}') )
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($(LANG=C git branch -vv | awk '/: gone]/{print $1}'))
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no local branches to trim."
@@ -202,7 +204,6 @@ if [ $pruned -eq 1 ]; then
   done
 fi
 
-
 # stale
 if [ $stale -eq 1 ]; then
   command='git branch'
@@ -211,8 +212,8 @@ if [ $stale -eq 1 ]; then
     command="$command -r"
   fi
 
-  branches=( $($command | grep -v "^\*") )
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($($command | grep -v "^\*"))
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no stale branches to trim."
@@ -230,11 +231,10 @@ if [ $stale -eq 1 ]; then
   done
 fi
 
-
 # untracked
 if [ $untracked -eq 1 ]; then
-  branches=( $(git branch --format='%(if)%(upstream)%(then)%(else)%(refname:short)%(end)' | awk NF) )
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($(git branch --format='%(if)%(upstream)%(then)%(else)%(refname:short)%(end)' | awk NF))
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no untracked branches to trim."
@@ -248,28 +248,27 @@ if [ $untracked -eq 1 ]; then
   done
 fi
 
-
 # reset
 if [ -n "$reset" ]; then
   while true; do
     read -p "Are you sure you want to remove all local branches not on $reset? " choice
     case $(echo $choice | tr '[A-Z]' '[a-z]') in
-      y|yes) break;;
-      *) exit;;
+    y | yes) break ;;
+    *) exit ;;
     esac
   done
 
-  git fetch -p $reset > /dev/null 2>&1
+  git fetch -p $reset >/dev/null 2>&1
 
-  remote_branches=( $(git ls-remote --heads origin | cut -f 2) )
-  local_branches=( $(git branch | grep -vF $current_branch) )
+  remote_branches=($(git ls-remote --heads origin | cut -f 2))
+  local_branches=($(git branch | grep -vF $current_branch))
   branches=()
 
   for branch in "${local_branches[@]}"; do
     [[ ! " ${remote_branches[*]} " =~ " refs/heads/${branch} " ]] && branches+=($branch)
   done
 
-  branches=( $(filter_branches "${branches[@]}") )
+  branches=($(filter_branches "${branches[@]}"))
 
   if [ ${#branches} -eq 0 ]; then
     echo "No branches need to be trimmed."
@@ -280,6 +279,5 @@ if [ -n "$reset" ]; then
     git branch -D $branch
   done
 fi
-
 
 exit 0

--- a/git-trim
+++ b/git-trim
@@ -283,7 +283,7 @@ if [ -n "$reset" ]; then
   fi
 
   for branch in "${branches[@]}"; do
-    git branch -D $branch
+    remove_local_branch $branch
   done
 fi
 

--- a/git-trim
+++ b/git-trim
@@ -17,7 +17,7 @@ s,stale!          remove local branches without commits in the last 3 months
 u,untracked!      remove local branches not tracking a remote branch
 t,tracked!        remove the tracking branch from remote
 r,remote!         remove remote branches instead of local branches
-dry!              prints branches to output instead of deleting theme
+dry-run!          prints branches to output instead of deleting theme
 reset=?           remove all local branches except those existing on remote (default: origin)
 "
 
@@ -32,7 +32,7 @@ tracked=0
 untracked=0
 remote=0
 reset=''
-dry=0
+dry_run=0
 current_branch=$(git symbolic-ref -q --short HEAD)
 [ $# != 1 ] || pruned=1
 
@@ -48,7 +48,7 @@ while [ $# != 0 ]; do
   --remote) remote=1;;
   --reset=*) reset="${1#*=}";;
   --reset) reset='origin';;
-  --dry) dry=1;;
+  --dry-run) dry_run=1;;
   --) ;;
   esac
   shift

--- a/git-trim
+++ b/git-trim
@@ -18,7 +18,7 @@ u,untracked!      remove local branches not tracking a remote branch
 t,tracked!        remove the tracking branch from remote
 r,remote!         remove remote branches instead of local branches
 reset=?           remove all local branches except those existing on remote (default: origin)
-e,dry!            prints branches to output instead of deleting theme
+dry!            prints branches to output instead of deleting theme
 "
 
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"

--- a/git-trim
+++ b/git-trim
@@ -137,7 +137,7 @@ if [ $all -eq 1 ]; then
     command="$command -a"
   fi
 
-  branches=( $($command | grep -vF $current_branch ) )
+  branches=( $($command | grep -vF $current_branch) )
   branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
@@ -170,7 +170,7 @@ if [ $merged -eq 1 ]; then
     command="$command -r"
   fi
 
-  branches=( $($command --merged | grep -vF $current_branch) )
+  branches=( $($command --merged | grep -vF $current_branch ) )
   branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
@@ -182,7 +182,6 @@ if [ $merged -eq 1 ]; then
     if [ $remote -eq 1 ]; then
       remove_remote_branch ${branch%/*} ${branch#*/}
     else
-
       if [ $tracked -eq 1 ]; then
         remove_tracking_branch $branch
       fi

--- a/git-trim
+++ b/git-trim
@@ -71,7 +71,7 @@ remove_tracking_branch() {
 
 remove_remote_branch() {
   if [ $dry_run -eq 1 ]; then
-    echo "$2 (on $1) will be trimmed."
+    echo "$2 will be deleted from $1."
   else
     git push -d $1 $2 >/dev/null 2>&1
     if [ $? -eq 0 ]; then
@@ -82,11 +82,12 @@ remove_remote_branch() {
 
 remove_local_branch() {
   if [ $dry_run -eq 1 ]; then
-    echo "$1 will be trimmed."
+    echo "$1 will be deleted."
   else
     git branch -D $1
   fi
 }
+
 
 # Defaults
 all=0
@@ -105,17 +106,17 @@ current_branch=$(git symbolic-ref -q --short HEAD)
 # Parse options
 while [ $# != 0 ]; do
   case "$1" in
-  --all) all=1;;
-  --stale) stale=1;;
-  --merged) merged=1;;
-  --pruned) pruned=1;;
-  --tracked) tracked=1;;
-  --untracked) untracked=1;;
-  --remote) remote=1;;
-  --reset=*) reset="${1#*=}";;
-  --reset) reset='origin';;
-  --dry-run) dry_run=1;;
-  --) ;;
+    --all) all=1;;
+    --stale) stale=1;;
+    --merged) merged=1;;
+    --pruned) pruned=1;;
+    --tracked) tracked=1;;
+    --untracked) untracked=1;;
+    --remote) remote=1;;
+    --reset=*) reset="${1#*=}";;
+    --reset) reset='origin';;
+    --dry-run) dry_run=1;;
+    --) ;;
   esac
   shift
 done

--- a/git-trim
+++ b/git-trim
@@ -103,17 +103,17 @@ current_branch=$(git symbolic-ref -q --short HEAD)
 # Parse options
 while [ $# != 0 ]; do
   case "$1" in
-  --all) all=1;;
-  --dry-run) dry_run=1;;
-  --merged) merged=1;;
-  --pruned) pruned=1;;
-  --remote) remote=1;;
-  --stale) stale=1;;
-  --tracked) tracked=1;;
-  --untracked) untracked=1;;
-  --reset=*) reset="${1#*=}";;
-  --reset) reset='origin';;
-  --);;
+    --all) all=1;;
+    --dry-run) dry_run=1;;
+    --merged) merged=1;;
+    --pruned) pruned=1;;
+    --remote) remote=1;;
+    --stale) stale=1;;
+    --tracked) tracked=1;;
+    --untracked) untracked=1;;
+    --reset=*) reset="${1#*=}";;
+    --reset) reset='origin';;
+    --) ;;
   esac
   shift
 done
@@ -253,12 +253,12 @@ if [ -n "$reset" ]; then
   while true; do
     read -p "Are you sure you want to remove all local branches not on $reset? " choice
     case $(echo $choice | tr '[A-Z]' '[a-z]') in
-    y | yes) break ;;
-    *) exit ;;
+      y|yes) break;;
+      *) exit;;
     esac
   done
 
-  git fetch -p $reset >/dev/null 2>&1
+  git fetch -p $reset > /dev/null 2>&1
 
   remote_branches=( $(git ls-remote --heads origin | cut -f 2) )
   local_branches=( $(git branch | grep -vF $current_branch) )
@@ -268,7 +268,7 @@ if [ -n "$reset" ]; then
     [[ ! " ${remote_branches[*]} " =~ " refs/heads/${branch} " ]] && branches+=($branch)
   done
 
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "No branches need to be trimmed."

--- a/git-trim
+++ b/git-trim
@@ -100,6 +100,7 @@ untracked=0
 current_branch=$(git symbolic-ref -q --short HEAD)
 [ $# != 1 ] || pruned=1
 
+
 # Parse options
 while [ $# != 0 ]; do
   case "$1" in
@@ -117,6 +118,7 @@ while [ $# != 0 ]; do
   esac
   shift
 done
+
 
 # all
 if [ $all -eq 1 ]; then
@@ -158,6 +160,7 @@ if [ $all -eq 1 ]; then
   done
 fi
 
+
 # merged
 if [ $merged -eq 1 ]; then
   command='git branch'
@@ -188,6 +191,7 @@ if [ $merged -eq 1 ]; then
   done
 fi
 
+
 # pruned
 if [ $pruned -eq 1 ]; then
   prune_all
@@ -203,6 +207,7 @@ if [ $pruned -eq 1 ]; then
     remove_local_branch $branch
   done
 fi
+
 
 # stale
 if [ $stale -eq 1 ]; then
@@ -231,6 +236,7 @@ if [ $stale -eq 1 ]; then
   done
 fi
 
+
 # untracked
 if [ $untracked -eq 1 ]; then
   branches=( $(git branch --format='%(if)%(upstream)%(then)%(else)%(refname:short)%(end)' | awk NF) )
@@ -247,6 +253,7 @@ if [ $untracked -eq 1 ]; then
     fi
   done
 fi
+
 
 # reset
 if [ -n "$reset" ]; then

--- a/git-trim
+++ b/git-trim
@@ -92,11 +92,11 @@ all=0
 dry_run=0
 merged=0
 pruned=0
-remote=0
-reset=''
 stale=0
 tracked=0
 untracked=0
+remote=0
+reset=''
 current_branch=$(git symbolic-ref -q --short HEAD)
 [ $# != 1 ] || pruned=1
 
@@ -104,17 +104,17 @@ current_branch=$(git symbolic-ref -q --short HEAD)
 # Parse options
 while [ $# != 0 ]; do
   case "$1" in
-    --all) all=1;;
-    --dry-run) dry_run=1;;
-    --merged) merged=1;;
-    --pruned) pruned=1;;
-    --remote) remote=1;;
-    --stale) stale=1;;
-    --tracked) tracked=1;;
-    --untracked) untracked=1;;
-    --reset=*) reset="${1#*=}";;
-    --reset) reset='origin';;
-    --) ;;
+  --all) all=1;;
+  --stale) stale=1;;
+  --merged) merged=1;;
+  --pruned) pruned=1;;
+  --tracked) tracked=1;;
+  --untracked) untracked=1;;
+  --remote) remote=1;;
+  --reset=*) reset="${1#*=}";;
+  --reset) reset='origin';;
+  --dry-run) dry_run=1;;
+  --) ;;
   esac
   shift
 done
@@ -125,8 +125,8 @@ if [ $all -eq 1 ]; then
   while true; do
     read -p "Are you sure you want to remove all branches? " choice
     case $(echo $choice | tr '[A-Z]' '[a-z]') in
-    y|yes) break;;
-    *) exit;;
+      y|yes) break;;
+      *) exit;;
     esac
   done
 
@@ -136,7 +136,7 @@ if [ $all -eq 1 ]; then
     command="$command -a"
   fi
 
-  branches=( $($command | grep -vF $current_branch) )
+  branches=( $($command | grep -vF $current_branch ) )
   branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
@@ -286,5 +286,6 @@ if [ -n "$reset" ]; then
     git branch -D $branch
   done
 fi
+
 
 exit 0

--- a/git-trim
+++ b/git-trim
@@ -18,10 +18,41 @@ u,untracked!      remove local branches not tracking a remote branch
 t,tracked!        remove the tracking branch from remote
 r,remote!         remove remote branches instead of local branches
 reset=?           remove all local branches except those existing on remote (default: origin)
+e,dry!            prints branches to output instead of deleting theme
 "
 
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
+# Defaults
+all=0
+merged=0
+pruned=0
+stale=0
+tracked=0
+untracked=0
+remote=0
+reset=''
+dry=0
+current_branch=$(git symbolic-ref -q --short HEAD)
+[ $# != 1 ] || pruned=1
+
+# Parse options
+while [ $# != 0 ]; do
+  case "$1" in
+  --all) all=1;;
+  --stale) stale=1;;
+  --merged) merged=1;;
+  --pruned) pruned=1;;
+  --tracked) tracked=1;;
+  --untracked) untracked=1;;
+  --remote) remote=1;;
+  --reset=*) reset="${1#*=}";;
+  --reset) reset='origin';;
+  --dry) dry=1;;
+  --) ;;
+  esac
+  shift
+done
 
 # Functions
 filter_branches() {
@@ -75,37 +106,13 @@ remove_remote_branch() {
   fi
 }
 
-
-# Defaults
-all=0
-merged=0
-pruned=0
-stale=0
-tracked=0
-untracked=0
-remote=0
-reset=''
-current_branch=$(git symbolic-ref -q --short HEAD)
-[ $# != 1 ] || pruned=1
-
-
-# Parse options
-while [ $# != 0 ]; do
-  case "$1" in
-  --all) all=1;;
-  --stale) stale=1;;
-  --merged) merged=1;;
-  --pruned) pruned=1;;
-  --tracked) tracked=1;;
-  --untracked) untracked=1;;
-  --remote) remote=1;;
-  --reset=*) reset="${1#*=}";;
-  --reset) reset='origin';;
-  --) ;;
-  esac
-  shift
-done
-
+remove_local_branch() {
+  if [ $dry -eq 1 ]; then
+    echo "${$1} will be trimmed."
+  else
+    git branch -D $1
+  fi
+}
 
 # all
 if [ $all -eq 1 ]; then
@@ -138,7 +145,7 @@ if [ $all -eq 1 ]; then
         remove_remote_branch ${name%/*} ${name#*/}
       fi
     else
-      git branch -D $branch
+      remove_local_branch $branch
 
       if [ $tracked -eq 1 ]; then
         remove_tracking_branch $branch
@@ -168,11 +175,12 @@ if [ $merged -eq 1 ]; then
     if [ $remote -eq 1 ]; then
       remove_remote_branch ${branch%/*} ${branch#*/}
     else
+      
       if [ $tracked -eq 1 ]; then
         remove_tracking_branch $branch
       fi
 
-      git branch -d $branch
+      remove_local_branch $branch
     fi
   done
 fi
@@ -190,7 +198,7 @@ if [ $pruned -eq 1 ]; then
   fi
 
   for branch in "${branches[@]}"; do
-    git branch -D $branch
+    remove_local_branch $branch
   done
 fi
 
@@ -216,7 +224,7 @@ if [ $stale -eq 1 ]; then
       if [ $remote -eq 1 ]; then
         remove_remote_branch ${branch%/*} ${branch#*/}
       else
-        git branch -D $branch
+        remove_local_branch $branch
       fi
     fi
   done
@@ -235,7 +243,7 @@ if [ $untracked -eq 1 ]; then
 
   for branch in "${branches[@]}"; do
     if [ "$branch" != "$current_branch" ]; then
-      git branch -D $branch
+      remove_local_branch $branch
     fi
   done
 fi

--- a/git-trim
+++ b/git-trim
@@ -17,8 +17,8 @@ s,stale!          remove local branches without commits in the last 3 months
 u,untracked!      remove local branches not tracking a remote branch
 t,tracked!        remove the tracking branch from remote
 r,remote!         remove remote branches instead of local branches
+dry!              prints branches to output instead of deleting theme
 reset=?           remove all local branches except those existing on remote (default: origin)
-dry!            prints branches to output instead of deleting theme
 "
 
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"

--- a/git-trim
+++ b/git-trim
@@ -23,6 +23,7 @@ u,untracked!      remove local branches not tracking a remote branch
 
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
+
 # Functions
 filter_branches() {
   local exclude=( $(git config gt.exclude) )

--- a/git-trim
+++ b/git-trim
@@ -25,7 +25,7 @@ SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
 # Functions
 filter_branches() {
-  local exclude=($(git config gt.exclude))
+  local exclude=( $(git config gt.exclude) )
 
   if [ ${#exclude} -eq 0 ]; then
     echo "$@"
@@ -52,7 +52,7 @@ filter_branches() {
 }
 
 prune_all() {
-  git fetch --all -p >/dev/null 2>&1
+  git fetch --all -p > /dev/null 2>&1
 }
 
 remove_tracking_branch() {
@@ -103,17 +103,17 @@ current_branch=$(git symbolic-ref -q --short HEAD)
 # Parse options
 while [ $# != 0 ]; do
   case "$1" in
-  --all) all=1 ;;
-  --stale) stale=1 ;;
-  --merged) merged=1 ;;
-  --pruned) pruned=1 ;;
-  --tracked) tracked=1 ;;
-  --untracked) untracked=1 ;;
-  --remote) remote=1 ;;
-  --reset=*) reset="${1#*=}" ;;
-  --reset) reset='origin' ;;
-  --dry-run) dry_run=1 ;;
-  --) ;;
+  --all) all=1;;
+  --dry-run) dry_run=1;;
+  --merged) merged=1;;
+  --pruned) pruned=1;;
+  --remote) remote=1;;
+  --stale) stale=1;;
+  --tracked) tracked=1;;
+  --untracked) untracked=1;;
+  --reset=*) reset="${1#*=}";;
+  --reset) reset='origin';;
+  --);;
   esac
   shift
 done
@@ -123,8 +123,8 @@ if [ $all -eq 1 ]; then
   while true; do
     read -p "Are you sure you want to remove all branches? " choice
     case $(echo $choice | tr '[A-Z]' '[a-z]') in
-    y | yes) break ;;
-    *) exit ;;
+    y|yes) break;;
+    *) exit;;
     esac
   done
 
@@ -134,8 +134,8 @@ if [ $all -eq 1 ]; then
     command="$command -a"
   fi
 
-  branches=($($command | grep -vF $current_branch))
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $($command | grep -vF $current_branch) )
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "No branches need to be trimmed."
@@ -166,8 +166,8 @@ if [ $merged -eq 1 ]; then
     command="$command -r"
   fi
 
-  branches=($($command --merged | grep -vF $current_branch))
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $($command --merged | grep -vF $current_branch) )
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no merged branches to trim."
@@ -191,8 +191,8 @@ fi
 # pruned
 if [ $pruned -eq 1 ]; then
   prune_all
-  branches=($(LANG=C git branch -vv | awk '/: gone]/{print $1}'))
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $(LANG=C git branch -vv | awk '/: gone]/{print $1}') )
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no local branches to trim."
@@ -212,8 +212,8 @@ if [ $stale -eq 1 ]; then
     command="$command -r"
   fi
 
-  branches=($($command | grep -v "^\*"))
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $($command | grep -v "^\*") )
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no stale branches to trim."
@@ -233,8 +233,8 @@ fi
 
 # untracked
 if [ $untracked -eq 1 ]; then
-  branches=($(git branch --format='%(if)%(upstream)%(then)%(else)%(refname:short)%(end)' | awk NF))
-  branches=($(filter_branches "${branches[@]}"))
+  branches=( $(git branch --format='%(if)%(upstream)%(then)%(else)%(refname:short)%(end)' | awk NF) )
+  branches=( $(filter_branches "${branches[@]}") )
 
   if [ ${#branches} -eq 0 ]; then
     echo "There are no untracked branches to trim."
@@ -260,8 +260,8 @@ if [ -n "$reset" ]; then
 
   git fetch -p $reset >/dev/null 2>&1
 
-  remote_branches=($(git ls-remote --heads origin | cut -f 2))
-  local_branches=($(git branch | grep -vF $current_branch))
+  remote_branches=( $(git ls-remote --heads origin | cut -f 2) )
+  local_branches=( $(git branch | grep -vF $current_branch) )
   branches=()
 
   for branch in "${local_branches[@]}"; do


### PR DESCRIPTION
## Description

Inspired by Laravel `php artisan migrate --pretend`, that prints SQL queries instead of running them on the database. 

I have added a new flag `--dry-run` to `git trim`, that prints branches going to be trimmed instead of actually deleting them.

This will solve the problem of not knowing what branches are going to be impacted, fearing to delete unwanted branches.

### Changes

- Added `--dry-run` flag to `git trim` option.
- Added `remove_local_branch` function.
- Sorted flags by alphabetical order.