### PR TITLE
Add glob-based branch exclude support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ git config gt.exclude "dev staging"
 # Always exclude the "dev" and "staging" branches from removal
 ```
 
+You may also use glob patterns (wildcards) to exclude branches matching a pattern.
+
+```sh
+git config gt.exclude "dev staging save/*"
+# Exclude "dev", "staging", and any branch starting with "save/"
+```
+
 ## Disclaimer
 Some of the options in this command remove branches without warning. Once a branch is removed, it might not be recoverable. You are solely responsible when running this command.
 

--- a/git-trim
+++ b/git-trim
@@ -27,7 +27,13 @@ SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
 # Functions
 filter_branches() {
+  local restore_glob=0
+  if [[ ! -o noglob ]]; then
+    restore_glob=1
+    set -o noglob
+  fi
   local exclude=( $(git config gt.exclude) )
+  [ $restore_glob -eq 1 ] && set +o noglob
 
   if [ ${#exclude} -eq 0 ]; then
     echo "$@"
@@ -39,14 +45,22 @@ filter_branches() {
   for branch in "$@"; do
     if [ $remote -eq 1 ]; then
       for excluded in "${exclude[@]}"; do
-        if [[ "$branch" == *"/$excluded" ]]; then
+        if [[ "$branch" == */$excluded ]]; then
           continue 2
         fi
       done
 
-      branches+=($branch)
+      branches+=("$branch")
     else
-      [[ ! " ${exclude[*]} " =~ " $branch " ]] && branches+=($branch)
+      local matched=0
+      for excluded in "${exclude[@]}"; do
+        if [[ "$branch" == $excluded ]]; then
+          matched=1
+          break
+        fi
+      done
+
+      [ $matched -eq 0 ] && branches+=("$branch")
     fi
   done
 


### PR DESCRIPTION
# Glob/Wildcard Support for `gt.exclude` — Implementation Summary

This resolves https://github.com/jasonmccreary/git-trim/issues/18 by adding glob pattern (wildcard) support to the `gt.exclude` Git config setting.

## What changed

### `git-trim` — `filter_branches()` function

**Local branch matching** was previously a single-line regex substring check:

```bash
[[ ! " ${exclude[*]} " =~ " $branch " ]] && branches+=($branch)
```

This only supported exact branch name matches. It has been replaced with a loop that uses bash's `[[ == ]]` glob matching:

```bash
for excluded in "${exclude[@]}"; do
  if [[ "$branch" == $excluded ]]; then
    matched=1
    break
  fi
done
```

By leaving `$excluded` unquoted on the right-hand side of `==` inside `[[ ]]`, bash interprets glob characters (`*`, `?`, `[...]`). Plain strings (no glob characters) still match exactly as before.

**Remote branch matching** had the same quoting issue. Changed from:

```bash
if [[ "$branch" == *"/$excluded" ]]; then
```

to:

```bash
if [[ "$branch" == */$excluded ]]; then
```

Unquoting `$excluded` enables glob expansion for remote branches as well (e.g., `origin/save/test` now matches the pattern `save/*`).

**Glob-safe config reading** — the `$(git config gt.exclude)` expansion is now wrapped with `set -o noglob` / `set +o noglob` to prevent the shell from expanding wildcards against the filesystem at assignment time. Without this, a pattern like `save/*` could be expanded to actual filenames if a matching directory exists in the working tree.

**Quoted array appends** — `branches+=($branch)` changed to `branches+=("$branch")` to prevent accidental word splitting or glob expansion when building the result array.

## Design Decisions

1. **Bash built-in glob matching** — Uses `[[ "$branch" == $pattern ]]` which is a native bash feature. No external tools or dependencies required. This supports `*` (match any string), `?` (match single character), and `[...]` (character classes).

2. **No breaking changes** — For exclude values without glob characters (e.g., `dev`, `staging`), the `==` comparison behaves identically to an exact string match. Existing configurations continue to work as before.

3. **Glob suppression during config read** — `set -o noglob` is toggled only around the config assignment and restored immediately after, avoiding side effects on the rest of the script.

4. **Scope limited to globs, not regex** — Glob patterns are the natural expectation for branch name matching (consistent with `.gitignore`, `git branch --list`, etc.). Full regex support was not added to keep it simple and intuitive.

## Usage Example

```sh
# Exclude exact branch names
git config gt.exclude "dev staging"

# Exclude branches matching a glob pattern
git config gt.exclude "dev staging save/*"
# This will protect: dev, staging, save/wip, save/feature-x, etc.
```
